### PR TITLE
Test cases that fail

### DIFF
--- a/src/main/java/com/j256/simplemagic/ContentInfoUtil.java
+++ b/src/main/java/com/j256/simplemagic/ContentInfoUtil.java
@@ -160,6 +160,39 @@ public class ContentInfoUtil {
 		}
 	}
 
+	
+
+	/**
+	 * Construct a magic utility using the magic entries from an inputstream
+	 * 
+	 * @param magicFile An inputstream representing a magic file
+	 * @throws IOException
+	 *             If there was a problem reading the magic entries from the internal magic file.
+	 */
+	public ContentInfoUtil(InputStream magicFile) throws IOException {
+		this(magicFile, null);
+	}
+
+	
+	/**
+	 * Construct a magic utility using the magic entries from an inputstream. 
+	 * This also allows the caller to log any errors discovered in the file(s).
+
+	 * @param magicFile An inputstream representing a magic file
+	 * @param errorCallBack
+	 *            Call back which shows any problems with the magic entries loaded.
+	 * @throws IOException
+	 *             If there was a problem reading the magic entries from the internal magic file.
+	 */
+	public ContentInfoUtil(InputStream magicFile, ErrorCallBack errorCallBack) throws IOException {
+		this.errorCallBack = errorCallBack;
+		this.magicEntries = readEntriesFromStream(magicFile);
+		if (this.magicEntries == null) {
+			throw new IllegalArgumentException("Error reading magic file from provided stream.");
+		}
+	}
+
+	
 	/**
 	 * Return the content type for the file-path or null if none of the magic entries matched.
 	 * 
@@ -311,6 +344,21 @@ public class ContentInfoUtil {
 		}
 	}
 
+	private MagicEntries readEntriesFromStream(InputStream stream) throws FileNotFoundException, IOException {
+		if (stream != null) {
+			InputStreamReader reader = new InputStreamReader(stream);
+			try {
+				return readEntries(reader);
+			} finally {
+				closeQuietly(reader);
+			}
+		} else {
+			return null;
+		}
+	}
+
+	
+	
 	private MagicEntries readEntriesFromResource(String resource) throws IOException {
 		InputStream stream = getClass().getResourceAsStream(resource);
 		if (stream == null) {

--- a/src/test/java/com/j256/simplemagic/integration/AbstractMagicTest.java
+++ b/src/test/java/com/j256/simplemagic/integration/AbstractMagicTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Rob Stryker and Contributors (as per source history)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j256.simplemagic.integration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import com.j256.simplemagic.ContentInfo;
+import com.j256.simplemagic.ContentInfoUtil;
+
+import junit.framework.TestCase;
+
+public abstract class AbstractMagicTest extends TestCase {
+
+	protected void runMagicAndFileTestOp(
+			String magicFileContents, byte[] fileToTest,
+			String expectedResult) throws IOException {
+
+		
+		ContentInfoUtil contentInfoUtil = new ContentInfoUtil(new ByteArrayInputStream(magicFileContents.getBytes()));
+		ContentInfo result = contentInfoUtil.findMatch(fileToTest);
+		String msg = result.getMessage();
+		System.out.println(msg);
+		assertEquals(expectedResult, msg);
+
+	}
+	
+	protected void runMagicAndFileTestOpNullMatch(
+			String magicFileContents, byte[] fileToTest) throws IOException {
+
+		ContentInfoUtil contentInfoUtil = new ContentInfoUtil(new ByteArrayInputStream(magicFileContents.getBytes()));
+		ContentInfo result = contentInfoUtil.findMatch(fileToTest);
+		assertNull(result);
+	}
+
+	public static byte[] hex2Bytes(String s) {
+		int len = s.length();
+		byte[] data = new byte[len / 2];
+		for (int i = 0; i < len; i += 2) {
+			data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4) + Character.digit(s.charAt(i + 1), 16));
+		}
+		return data;
+	}
+	
+
+	public static byte[] string2ASCII(String str) {
+		char[] buffer = str.toCharArray();
+		byte[] b = new byte[buffer.length];
+		for (int i = 0; i < b.length; i++) {
+			b[i] = (byte) buffer[i];
+		}
+		return b;
+	}
+	public static byte[] combine( byte[][] arr) {
+		int total = 0;
+		for( int i = 0; i < arr.length; i++ ) {
+			total += arr[i].length;
+		}
+		byte[] ret = new byte[total];
+		int count = 0;
+		for( int i = 0; i < arr.length; i++ ) {
+			for( int j = 0; j < arr[i].length; j++ ) {
+				ret[count++] = arr[i][j];
+			}
+		}
+		return ret;
+	}
+}

--- a/src/test/java/com/j256/simplemagic/integration/IntegrationTest.java
+++ b/src/test/java/com/j256/simplemagic/integration/IntegrationTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Rob Stryker and Contributors (as per source history)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j256.simplemagic.integration;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/**
+ * Run tests from a real magic file
+ */
+public class IntegrationTest extends AbstractMagicTest {
+	public void testRiscOSChunk() throws IOException {
+		String magicFile = "0\tlelong\t0xc3cbc6c5\tRISC OS Chunk data";
+		byte[] fileToTest = hex2Bytes("C5C6CbC3");
+		String expectedResults = "RISC OS Chunk data";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+	
+	public void testRiscOSChunkAOF() throws IOException {
+		String magicFile = "0\tlelong\t0xc3cbc6c5\tRISC OS Chunk data\n"
+				+ ">12 string OBJ_ \\b, AOF object";
+
+		byte[] hex = hex2Bytes("C5C6CbC3");
+		byte[] objpart = string2ASCII("OBJ_\0aaaaaaa");
+		byte[] fileToTest = combine(new byte[][] { hex, hex, hex, objpart});
+
+		String expectedResults = "RISC OS Chunk data, AOF object";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	public void testRiscOSChunkALF() throws IOException {
+		String magicFile = "0\tlelong\t0xc3cbc6c5\tRISC OS Chunk data\n"
+				+ ">12 string OBJ_ \\b, AOF object\n"
+				+ ">12 string LIB_ \\b, ALF object";
+
+		byte[] hex = hex2Bytes("C5C6CbC3");
+		byte[] objpart = string2ASCII("LIB_\0aaaaaaa");
+		byte[] fileToTest = combine(new byte[][] { hex, hex, hex, objpart});
+
+		String expectedResults = "RISC OS Chunk data, ALF object";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+
+	public void testRiscOSCAIFExec() throws IOException {
+		String magicFile = "16 lelong 0xef000011 RISC OS AIF executable";
+
+		byte[] filler = hex2Bytes("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+		byte[] objpart = hex2Bytes("110000EF");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+
+		String expectedResults = "RISC OS AIF executable";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+	
+	public void testRiscOSDraw() throws IOException {
+		String magicFile = "0 string Draw RISC OS Draw file data";
+		byte[] fileToTest = string2ASCII("Draw_____________");
+		String expectedResults = "RISC OS Draw file data";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+	
+	public void testRiscOSFont0() throws IOException {
+		String magicFile = "0 string FONT\\0 RISC OS outline font data,\n"
+				+ ">5 byte x version %d";
+		byte[] filler = string2ASCII("FONT");
+		byte[] objpart = hex2Bytes("0006");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+		String expectedResults = "RISC OS outline font data, version 6";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	public void testRiscOSFont1() throws IOException {
+		String magicFile = "0 string FONT\\1 RISC OS 1bpp font data,\n"
+				+ ">5 byte x version %d";
+		byte[] filler = string2ASCII("FONT");
+		byte[] objpart = hex2Bytes("0106");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+		String expectedResults = "RISC OS 1bpp font data, version 6";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	public void testRiscOSFont4() throws IOException {
+		String magicFile = "0 string FONT\\4 RISC OS 4bpp font data,\n"
+				+ ">5 byte x version %d";
+		byte[] filler = string2ASCII("FONT");
+		byte[] objpart = hex2Bytes("0406");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+		String expectedResults = "RISC OS 4bpp font data, version 6";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	public void testRiscOSFont1FailsFont4() throws IOException {
+		String magicFile = "0 string FONT\\1 RISC OS 1bpp font data,\n"
+				+ ">5 byte x version %d";
+		byte[] filler = string2ASCII("FONT");
+		byte[] objpart = hex2Bytes("0406");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+		runMagicAndFileTestOpNullMatch(magicFile, fileToTest);
+	}
+
+	public void testRiscOSMusicFile() throws IOException {
+		String magicFile = "0 string Maestro\\r RISC OS music file\n"
+				+ ">8 byte x version %d\n"
+				+ ">8 byte x type %d";
+
+		byte[] filler = string2ASCII("Maestro\r");
+		byte[] objpart = hex2Bytes("04aaaaaaaa");
+		byte[] fileToTest = combine(new byte[][] { filler, objpart});
+		String expectedResults = "RISC OS music file version 4 type 4";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	
+	/*
+	 * The magic definition for the next few tests
+	 */
+	private String digitalSymphonyMagicDefinition() {
+		return new String(
+		"0               string  \\x02\\x01\\x13\\x13\\x13\\x01\\x0d\\x10        Digital Symphony sound sample (RISC OS),\n" +
+		">8              byte    x       version %d,\n" +
+		">9              pstring x       named \"%s\",\n" +
+		">(9.b+19)       byte    =0      8-bit logarithmic\n" +
+		">(9.b+19)       byte    =1      LZW-compressed linear\n" +
+		">(9.b+19)       byte    =2      8-bit linear signed\n" +
+		">(9.b+19)       byte    =3      16-bit linear signed\n" +
+		">(9.b+19)       byte    =4      SigmaDelta-compressed linear\n" +
+		">(9.b+19)       byte    =5      SigmaDelta-compressed logarithmic\n" +
+		">(9.b+19)       byte    >5      unknown format");
+
+	}
+	
+	/*
+	 * These test pstring
+	 */
+	
+	/*
+	 * printing name in pstring, and tests a dereferenced byte
+	 */
+	public void testDigitalSymphony1() throws IOException {
+		String magicFile = digitalSymphonyMagicDefinition();
+		byte[] objpart = hex2Bytes("0201131313010d100505");
+		byte[] filler = string2ASCII("TESTING");
+		byte[] fileToTest = combine(new byte[][] { objpart, filler});
+		
+		String expectedResults = 
+				"Digital Symphony sound sample (RISC OS), version 5, named \"TESTI\",";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	/*
+	 * Increasing size of pstring increases the string being printed
+	 */
+	public void testDigitalSymphony1a() throws IOException {
+		String magicFile = digitalSymphonyMagicDefinition();
+		byte[] objpart = hex2Bytes("0201131313010d100507");
+		byte[] filler = string2ASCII("TESTING");
+		byte[] fileToTest = combine(new byte[][] { objpart, filler});
+		String expectedResults = 
+				"Digital Symphony sound sample (RISC OS), version 5, named \"TESTING\",";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	
+	
+	public void testDigitalSymphony2() throws IOException {
+		String magicFile = digitalSymphonyMagicDefinition();
+		//           magic key 7-bytes    |vers | pstring |    9 byte unknown 
+		String hex = "0201131313010d10" + "05" + "027272" + "aaaaaaaaaaaaaaaaaa" + "04";
+		byte[] fileToTest = hex2Bytes(hex);
+		String expectedResults = 
+				"Digital Symphony sound sample (RISC OS), version 5, " 
+						+ "named \"rr\", SigmaDelta-compressed linear";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	public void testDigitalSymphony3() throws IOException {
+		String magicFile = digitalSymphonyMagicDefinition();
+		//           magic key 7-bytes    |vers | pstring |    9 byte unknown 
+		String hex = "0201131313010d10" + "05" + "0C726f62206973206772656174" + "aaaaaaaaaaaaaaaaaa" + "04";
+		byte[] fileToTest = hex2Bytes(hex);
+		String expectedResults = 
+				"Digital Symphony sound sample (RISC OS), version 5, " 
+						+ "named \"rob is great\", SigmaDelta-compressed linear";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	/*
+	 * Tests greater-than comparison
+	 */
+	public void testDigitalSymphony4() throws IOException {
+		String magicFile = digitalSymphonyMagicDefinition();
+		//           magic key 7-bytes    |vers | pstring |    9 byte unknown 
+		String hex = "0201131313010d10" + "05" + "0C726f62206973206772656174" + "aaaaaaaaaaaaaaaaaa" + "07";
+		byte[] fileToTest = hex2Bytes(hex);
+		String expectedResults = 
+				"Digital Symphony sound sample (RISC OS), version 5, " 
+						+ "named \"rob is great\", unknown format";
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+	
+	private String digitalSymphonySongDefinition() {
+		String ret = 
+		"0       string  \\x02\\x01\\x13\\x13\\x14\\x12\\x01\\x0b        Digital Symphony song (RISC OS),\n" +
+		">8      byte    x       version %d,\n" +
+		">9      byte    =1      1 voice,\n" +
+		">9      byte    !1      %d voices,\n" +
+		">10     leshort =1      1 track,\n" +
+		">10     leshort !1      %d tracks,\n" +
+		">12     leshort =1      1 pattern\n" +
+		">12     leshort !1      %d patterns\n";
+		return ret;
+	}
+	
+	public void testDigitalSymphonySong() throws IOException {
+		String magicFile = digitalSymphonySongDefinition();
+		//           magic key 7-bytes    |vers | voice | track | patterns 
+		String hex = "020113131412010b" + "05" + "03" + "0300" + "0300";
+		byte[] fileToTest = hex2Bytes(hex);
+		String expectedResults = 
+				"Digital Symphony song (RISC OS), version 5, 3 voices, 3 tracks, 3 patterns"; 
+		runMagicAndFileTestOp(magicFile, fileToTest, expectedResults);
+	}
+
+	
+
+}

--- a/src/test/java/com/j256/simplemagic/integration/NameTest.java
+++ b/src/test/java/com/j256/simplemagic/integration/NameTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Rob Stryker and Contributors (as per source history)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j256.simplemagic.integration;
+
+public class NameTest extends AbstractMagicTest {
+//	public void testNamedEntry() throws IOException {
+//		String magicFile = "0 name mynamedentry";
+//		MagicFileModel mfm = new MagicFileLoader().readMagicFile(
+//				new ByteArrayInputStream(magicFile.getBytes()));
+//		MagicNode mn = mfm.getNamedNode("mynamedentry");
+//		assertNotNull(mn);
+//		
+//		mn = mfm.getNamedNode("garbage");
+//		assertNull(mn);
+//	}
+//
+//	public void testUseNoOffsetEntry() throws IOException {
+//		String magicFile = 
+//				   "4  byte  0xF  match1 \n" +
+//		           ">0   use  test1\n" + 
+//				   "0   name test1\n" + 
+//				   ">0  byte  5   match2 \n";
+//		
+//		byte[] objpart = hex2Bytes("050000000F");
+//		runMagicAndFileTestOp(magicFile, objpart, "Test: match1 match2");
+//	}
+//	
+//	public void testUseWithOffsetEntry() throws IOException {
+//		String magicFile = 
+//				   "4  byte  0xF  match1 \n" +
+//		           ">8   use  test1\n" + 
+//				   "0   name test1\n" + 
+//				   ">0  byte  5   match2 \n";
+//		
+//		byte[] objpart = hex2Bytes("000000000F00000005");
+//		runMagicAndFileTestOp(magicFile, objpart, "Test: match1 match2");
+//	}
+//
+//	public void testUseFlipEndianEntry() throws IOException {
+//		String magicFile = 
+//				   "2  leshort  0xFF  match1 \n" +
+//		           ">5   use  ^test1\n" + 
+//				   "0   name test1\n" + 
+//				   ">0  leshort  5   match2 \n";
+//		//                                      space + LE-2 + buffer + BE-5  (bc flipped)
+//		byte[] objpart = hex2Bytes("0000" + "FF00" + "00" + "0005");
+//		runMagicAndFileTestOp(magicFile, objpart, "Test: match1 match2");
+//	}
+}

--- a/src/test/java/com/j256/simplemagic/integration/NumericComparisonTest.java
+++ b/src/test/java/com/j256/simplemagic/integration/NumericComparisonTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Rob Stryker and Contributors (as per source history)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j256.simplemagic.integration;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class NumericComparisonTest extends AbstractMagicTest {
+	
+	public void testNotEqualComparisonByte() throws IOException {
+		String magicFile = "0 byte !0 match";
+		byte[] objpart = hex2Bytes("0106");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("0006");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testGTComparisonByte() throws IOException {
+		String magicFile = "0 byte >5 match";
+		byte[] objpart = hex2Bytes("0606");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("0306");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testLTComparisonByte() throws IOException {
+		String magicFile = "0 byte <5 match";
+		byte[] objpart = hex2Bytes("0206");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("0806");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testANDComparisonByte() throws IOException {
+		String magicFile = "0 byte &3 match";
+		byte[] objpart = hex2Bytes("0706");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("0806");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testXORComparisonByte() throws IOException {
+		String magicFile = "0 byte ^0x24 match";
+		byte[] objpart = hex2Bytes("CA");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("CE");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testNegateComparisonByte() throws IOException {
+		String magicFile = "0 byte ~3 match";
+		byte[] objpart = hex2Bytes("FC");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("FF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	// short unsigned
+	public void testUnsignedByteGT() throws IOException {
+		String magicFile = "0 ubyte >0xF0 match";
+		byte[] objpart = hex2Bytes("FF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		objpart = hex2Bytes("F1");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("EF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("AA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("80");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("7F");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("00");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+	}
+
+	public void testSignedByteGT() throws IOException {
+		String magicFile = "0 byte >0xF0 match";
+		
+		// higher always
+		byte[] objpart = hex2Bytes("F1");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("FF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		// Higher bc of two's complement
+		objpart = hex2Bytes("00");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("7F");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		
+		// lower always
+		objpart = hex2Bytes("EF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("AA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("80");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+	
+	
+	/*
+	 * Shorts below
+	 */
+	
+	public void testANDComparisonShort() throws IOException {
+		String magicFile = "0 beshort &0xFF match";
+		byte[] objpart = hex2Bytes("FFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("FFF4");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+	
+
+	public void testXORComparisonShort() throws IOException {
+		String magicFile = "0 short ^0x24 match";
+		byte[] objpart = hex2Bytes("FFCA");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("FFCE");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+	
+	public void testNegateComparisonShort() throws IOException {
+		String magicFile = "0 beshort ~3 match";
+		byte[] objpart = hex2Bytes("FFFC");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("FFFE");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testShortWithMask() throws IOException {
+		String magicFile = "0 beshort&0xF >7 match";
+		byte[] objpart = hex2Bytes("FFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("000F");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		objpart = hex2Bytes("0009");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		objpart = hex2Bytes("0008");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		// fail bc not gt 7
+		objpart = hex2Bytes("0007");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+
+
+		objpart = hex2Bytes("FFF3");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("FFF0");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	// short unsigned
+	public void testUnsignedShortGT() throws IOException {
+		String magicFile = "0 ubeshort >0xF000 match";
+		byte[] objpart = hex2Bytes("FFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		objpart = hex2Bytes("F001");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("EFFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("AAAA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("8000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("7FFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("0000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+	}
+
+	public void testSignedShortGT() throws IOException {
+		String magicFile = "0 beshort >0xF000 match";
+		
+		// higher always
+		byte[] objpart = hex2Bytes("F001");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("FFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		// Higher bc of two's complement
+		objpart = hex2Bytes("0000");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("7FFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		
+		// lower always
+		objpart = hex2Bytes("EFFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("AAAA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("8000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+	}
+
+	
+	
+	
+	
+	
+	
+	
+
+	// short unsigned
+	public void testUnsignedLongGT() throws IOException {
+		String magicFile = "0 ubelong >0xF0000000 match";
+		byte[] objpart = hex2Bytes("FFFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+
+		objpart = hex2Bytes("F0000001");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("EFFFFFFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("AAAAAAAA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		
+		objpart = hex2Bytes("80000000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("7FFFFFFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+		objpart = hex2Bytes("00000000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+	}
+
+	public void testSignedLongGT() throws IOException {
+		String magicFile = "0 belong >0xF0000000 match";
+		
+		// higher always
+		byte[] objpart = hex2Bytes("F0000001");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("FFFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		// Higher bc of two's complement
+		objpart = hex2Bytes("00000000");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		objpart = hex2Bytes("7FFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		
+		// lower always
+		objpart = hex2Bytes("EFFFFFFF");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("AAAAAAAA");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+		objpart = hex2Bytes("80000000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+
+	}
+
+
+	public void testBEDouble() throws IOException {
+		String magicFile = "0 bedouble >8.64e+13 match";
+		
+		ByteBuffer bb = ByteBuffer.allocate(8);
+		bb.putDouble(Double.parseDouble("8.72e+13"));
+		bb.flip();
+		byte[] objpart = bb.array();
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		
+		bb = ByteBuffer.allocate(8);
+		bb.putDouble(Double.parseDouble("8.2e+13"));
+		bb.flip();
+		objpart = bb.array();
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}	
+
+	public void testLEDouble() throws IOException {
+		String magicFile = "0 ledouble >8.64e+13 match";
+		
+		ByteBuffer bb = ByteBuffer.allocate(8);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+		bb.putDouble(Double.parseDouble("8.72e+13"));
+		bb.flip();
+		byte[] objpart = bb.array();
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		
+		bb = ByteBuffer.allocate(8);
+		bb.order(ByteOrder.LITTLE_ENDIAN);
+		bb.putDouble(Double.parseDouble("8.2e+13"));
+		bb.flip();
+		objpart = bb.array();
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}	
+
+	public void testNotEqualComparisonQuad() throws IOException {
+		String magicFile = "0 bequad !0 match";
+		byte[] objpart = hex2Bytes("FFFFFFFFFFFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("0000000000000000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testGTComparisonQuad() throws IOException {
+		String magicFile = "0 bequad >0x7FFFFFFFFFFF0000 match";
+		byte[] objpart = hex2Bytes("7FFFFFFFFFFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("8000000000000000");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testGTComparisonUnsignedQuad() throws IOException {
+		String magicFile = "0 ubequad >0x7FFFFFFFFFFF0000 match";
+		byte[] objpart = hex2Bytes("7FFFFFFFFFFFFFFF");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+		
+		objpart = hex2Bytes("8000000000000000");
+		runMagicAndFileTestOp(magicFile, objpart, "match");
+	}
+
+	
+	
+}

--- a/src/test/java/com/j256/simplemagic/integration/PStringTest.java
+++ b/src/test/java/com/j256/simplemagic/integration/PStringTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Rob Stryker and Contributors (as per source history)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.j256.simplemagic.integration;
+
+import java.io.IOException;
+
+public class PStringTest extends AbstractMagicTest {
+	
+	public void testPString_Default() throws IOException {
+		String magicFile = "0 pstring x match";
+		byte[] objpart = hex2Bytes("05");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		objpart = hex2Bytes("77aa83475234");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	
+	public void testPString_B() throws IOException {
+		String magicFile = "0 pstring/B x match";
+		byte[] objpart = hex2Bytes("05");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		objpart = hex2Bytes("77aa83475234");
+		runMagicAndFileTestOpNullMatch(magicFile, objpart);
+	}
+
+	public void testPString_H() throws IOException {
+		// succeed on big endian
+		String magicFile = "0 pstring/H x match";
+		byte[] objpart = hex2Bytes("0005");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		// fail on little-endian
+		objpart = hex2Bytes("0500");
+		str = string2ASCII("RobHere");
+		toTest = combine(new byte[][]{objpart, str});
+		runMagicAndFileTestOpNullMatch(magicFile, toTest);
+	}
+
+	public void testPString_h() throws IOException {
+		// succeed on little endian
+		String magicFile = "0 pstring/h x match";
+		byte[] objpart = hex2Bytes("0500");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		// fail on big-endian
+		objpart = hex2Bytes("0005");
+		str = string2ASCII("RobHere");
+		toTest = combine(new byte[][]{objpart, str});
+		runMagicAndFileTestOpNullMatch(magicFile, toTest);
+	}
+
+
+	public void testPString_L() throws IOException {
+		// succeed on big endian
+		String magicFile = "0 pstring/L x match";
+		byte[] objpart = hex2Bytes("00000005");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		// fail on little-endian
+		objpart = hex2Bytes("05000000");
+		str = string2ASCII("RobHere");
+		toTest = combine(new byte[][]{objpart, str});
+		runMagicAndFileTestOpNullMatch(magicFile, toTest);
+	}
+
+	public void testPString_l() throws IOException {
+		// succeed on little endian
+		String magicFile = "0 pstring/l x match";
+		byte[] objpart = hex2Bytes("05000000");
+		byte[] str = string2ASCII("RobHere");
+		byte[] toTest = combine(new byte[][]{objpart, str});
+
+		runMagicAndFileTestOp(magicFile, toTest, "match");
+		
+		// fail on big-endian
+		objpart = hex2Bytes("00000005");
+		str = string2ASCII("RobHere");
+		toTest = combine(new byte[][]{objpart, str});
+		runMagicAndFileTestOpNullMatch(magicFile, toTest);
+	}
+
+}


### PR DESCRIPTION
Hey, I was checking out your code. It looked great and well organized compared to the crap I was developing ;)  

But when I applied my test cases to yours, there are a ton of failures.  Almost all of my tests have been verified against the linux  'file' command, especially those dealing with simple numeric comparisons. It's always possible I have some gaps, but, it seems there's a lot of bad behavior here that would prevent your codebase from working with a magic file. 

One of the biggest problems is your treatment of signed comparisons. For example, a 4-byte comparison (ie, long) of  0xF0000000  compared to 0x00000000 should show 0x00000000 as being greater, because in a 4-byte signed comparison,  0xF0000000 is actually negative. 

But there's a lot of other stuff that fails, like pstring.  

This patch is just some suggested test cases, though.  I don't have any fixes yet, because I haven't figured out how to work within your architecture yet. I'll see if I can get around to patches, but I'm not sure if I will. 