### PR TITLE
try to fix the problem where certain file with leading white spaces are not detected properly

### DIFF
--- a/src/main/java/com/j256/simplemagic/entries/MagicEntries.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicEntries.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 
 import com.j256.simplemagic.ContentInfo;
+import com.j256.simplemagic.ContentType;
 import com.j256.simplemagic.ContentInfoUtil.ErrorCallBack;
 import com.j256.simplemagic.logger.Logger;
 import com.j256.simplemagic.logger.LoggerFactory;
@@ -134,14 +135,23 @@ public class MagicEntries {
 		}
 		// first do the start byte ones
 		int index = (0xFF & bytes[0]);
+		ContentInfo info = null;
 		if (index < firstByteLinkedLists.length && firstByteLinkedLists[index] != null) {
-			ContentInfo info = findMatch(bytes, firstByteLinkedLists[index]);
-			if (info != null) {
+			info = findMatch(bytes, firstByteLinkedLists[index]);
+			if (info != null && !info.getContentType().equals(ContentType.OTHER)) {
 				// XXX: not sure if it is right to return if only a partial match here
 				return info;
 			}
 		}
-		return findMatch(bytes, entryLinkedList);
+		
+		ContentInfo retry = findMatch(bytes, entryLinkedList);
+		if (retry == null) {
+			return info;
+		} else { 
+			// return retry anyways, because retry is not null and it will not be worse that info which is either null or OTHER
+			return retry;
+		}
+		
 	}
 
 	private ContentInfo findMatch(byte[] bytes, MagicEntry entryLinkedList) {

--- a/src/main/java/com/j256/simplemagic/types/StringType.java
+++ b/src/main/java/com/j256/simplemagic/types/StringType.java
@@ -94,7 +94,13 @@ public class StringType implements MagicMatcher {
 
 	@Override
 	public byte[] getStartingBytes(Object testValue) {
-		return ((TestInfo) testValue).getStartingBytes();
+		TestInfo ti =  (TestInfo) testValue;
+
+		if (ti.caseInsensitive || ti.compactWhiteSpace || ti.optionalWhiteSpace) {
+			return null;
+		} else {
+			return ti.getStartingBytes();
+		}
 	}
 
 	/**

--- a/src/test/java/com/j256/simplemagic/ContentInfoUtilTest.java
+++ b/src/test/java/com/j256/simplemagic/ContentInfoUtilTest.java
@@ -42,7 +42,7 @@ public class ContentInfoUtilTest {
 					"application/vnd.openxmlformats-officedocument.wordprocessingml.document", "Microsoft Word 2007+"),
 			new FileType("/files/x.rtf", ContentType.RTF, "rtf", "text/rtf",
 					"Rich Text Format data, version 1, unknown character set unknown version"),
-			new FileType("/files/x.xml", ContentType.XML, "xml", "application/xml", "XML document text"),
+			new FileType("/files/x.xml", ContentType.XML, "xml", "application/xml", "XML 1 document text"), // version=1.0
 			new FileType("/files/jfif.jpg", ContentType.JPEG, "jpeg", "image/jpeg",
 					"JPEG image data, JFIF standard 1.01"),
 			// partial file here


### PR DESCRIPTION
I think the root cause of the bug is for StringType, if any of /[Bbc]* is specified, we should not optimize it and move the entry to firstByteLinkedLists, in that case, the match is equivalent to regular expression matching and we can not use the fixed testValue to calculate the index in firstByteLinkedLists. 

Specifically https://github.com/j256/simplemagic/issues/15, for this issue, the root cause is, the Html entry is moved to firstByteLinkedLists, but if the actual html start with \n, \n will be used the calculate the index in firstByteLinkedLists and firstByteLinkedLists will fail to detect the html file type, since Html entry was removed from entryLinkedList as well, we ended up failing to detect it as Html properly