### PR TITLE
Protection for number converters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+/.classpath
+/.project
+/.settings/

--- a/src/main/java/com/j256/simplemagic/endian/BigEndianConverter.java
+++ b/src/main/java/com/j256/simplemagic/endian/BigEndianConverter.java
@@ -33,7 +33,7 @@ public class BigEndianConverter implements EndianConverter {
 	}
 
 	private Long convertNumber(int offset, byte[] bytes, int size, int shift, int mask) {
-		if (offset + size > bytes.length) {
+		if (offset < 0 || offset + size > bytes.length) {
 			return null;
 		}
 		long value = 0;

--- a/src/main/java/com/j256/simplemagic/endian/LittleEndianConverter.java
+++ b/src/main/java/com/j256/simplemagic/endian/LittleEndianConverter.java
@@ -31,8 +31,8 @@ public class LittleEndianConverter implements EndianConverter {
 		return result;
 	}
 
-	public Long convertNumber(int offset, byte[] bytes, int size, int shift, int mask) {
-		if (offset + size > bytes.length) {
+	private Long convertNumber(int offset, byte[] bytes, int size, int shift, int mask) {
+		if (offset < 0 || offset + size > bytes.length) {
 			return null;
 		}
 		long value = 0;

--- a/src/main/java/com/j256/simplemagic/endian/MiddleEndianConverter.java
+++ b/src/main/java/com/j256/simplemagic/endian/MiddleEndianConverter.java
@@ -36,15 +36,15 @@ public class MiddleEndianConverter implements EndianConverter {
 		if (size != 4) {
 			throw new UnsupportedOperationException("Middle-endian only supports 4-byte integers");
 		}
-		if (offset + size > bytes.length) {
+		if (offset < 0 || offset + size > bytes.length) {
 			return null;
 		}
 		long value = 0;
 		// BADC
-		value = (value << shift) | (bytes[1] & mask);
-		value = (value << shift) | (bytes[0] & mask);
-		value = (value << shift) | (bytes[3] & mask);
-		value = (value << shift) | (bytes[2] & mask);
+		value = (value << shift) | (bytes[offset + 1] & mask);
+		value = (value << shift) | (bytes[offset + 0] & mask);
+		value = (value << shift) | (bytes[offset + 3] & mask);
+		value = (value << shift) | (bytes[offset + 2] & mask);
 		return value;
 	}
 }

--- a/src/test/java/com/j256/simplemagic/endian/BigEndianConverterTest.java
+++ b/src/test/java/com/j256/simplemagic/endian/BigEndianConverterTest.java
@@ -1,6 +1,7 @@
 package com.j256.simplemagic.endian;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -16,6 +17,8 @@ public class BigEndianConverterTest {
 		Long result = converter.convertNumber(0, bytes, 8);
 		byte[] outBytes = converter.convertToByteArray(result, 8);
 		assertTrue(Arrays.equals(bytes, outBytes));
+		assertNull(converter.convertNumber(0, bytes, bytes.length + 1));
+		assertNull(converter.convertNumber(-1, bytes, bytes.length));
 	}
 
 	@Test

--- a/src/test/java/com/j256/simplemagic/endian/LittleEndianConverterTest.java
+++ b/src/test/java/com/j256/simplemagic/endian/LittleEndianConverterTest.java
@@ -1,6 +1,7 @@
 package com.j256.simplemagic.endian;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -16,6 +17,8 @@ public class LittleEndianConverterTest {
 		Long result = converter.convertNumber(0, bytes, 8);
 		byte[] outBytes = converter.convertToByteArray(result, 8);
 		assertTrue(Arrays.equals(bytes, outBytes));
+		assertNull(converter.convertNumber(0, bytes, bytes.length + 1));
+		assertNull(converter.convertNumber(-1, bytes, bytes.length));
 	}
 
 	@Test

--- a/src/test/java/com/j256/simplemagic/endian/MiddleEndianConverterTest.java
+++ b/src/test/java/com/j256/simplemagic/endian/MiddleEndianConverterTest.java
@@ -28,6 +28,11 @@ public class MiddleEndianConverterTest {
 		long val = converter.convertId3(0, new byte[] { 1, 2, 3, 4 }, 4);
 		// BADC: 2*2^21 + 1*2^14 + 4*2^7 + 3
 		assertEquals(4211203, val);
+
+		// shift over to test offset
+		val = converter.convertId3(2, new byte[] { 0, 0, 1, 2, 3, 4 }, 4);
+		// BADC: 2*2^21 + 1*2^14 + 4*2^7 + 3
+		assertEquals(4211203, val);
 	}
 
 	@Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/com/j256/simplemagic/endian/MiddleEndianConverterTest.java
+++ b/src/test/java/com/j256/simplemagic/endian/MiddleEndianConverterTest.java
@@ -19,6 +19,7 @@ public class MiddleEndianConverterTest {
 		assertEquals(33620995, val);
 		byte[] outBytes = converter.convertToByteArray(val, 4);
 		assertTrue(Arrays.equals(bytes, outBytes));
+		assertNull(converter.convertNumber(-1, bytes, 4));
 	}
 
 	@Test


### PR DESCRIPTION
* After an array of out bounds exception report, I've added protection against negative offsets.
* Fixed a problem with middle endian which was not obeying offset.
