### PR TITLE
Adding a test utility to parse and dump a 'magic' file.

### DIFF
--- a/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
@@ -125,7 +125,22 @@ public class MagicEntry {
 		return sb.toString();
 	}
 
-	/**
+	public String toString2() {
+		StringBuilder sb = new StringBuilder(toString() + ",addOffset " + addOffset +
+			",offset " + offset + ",offsetInfo " + offsetInfo + 
+			",matcher " + matcher.getClass().getSimpleName() + 
+			",andValue " + andValue + ",unsignedType " + unsignedType + 
+			",formatSpacePrefix " + formatSpacePrefix +
+			",clearFormat " + clearFormat);
+		if (children != null) {
+			for (MagicEntry entry: children) {
+				sb.append("\n").append(entry.toString2());
+			}
+		}
+		return sb.toString();
+	}
+
+        /**
 	 * Main processing method which can go recursive.
 	 */
 	private ContentData matchBytes(byte[] bytes, int prevOffset, int level, ContentData contentData) {
@@ -256,6 +271,11 @@ public class MagicEntry {
 			} else {
 				return (int) (val + add);
 			}
+		}
+		
+		public String toString() {
+			return "[" + offset + "," + converter.getClass().getSimpleName() +
+					"," + isId3 + "," + size + "," + add + "]";
 		}
 	}
 }

--- a/src/test/java/com/j256/simplemagic/entries/MagicEntryDumper.java
+++ b/src/test/java/com/j256/simplemagic/entries/MagicEntryDumper.java
@@ -1,0 +1,32 @@
+package com.j256.simplemagic.entries;
+
+import java.io.FileReader;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import com.j256.simplemagic.ContentInfoUtil;
+import com.j256.simplemagic.ContentInfoUtil.ErrorCallBack;
+
+public class MagicEntryDumper {
+
+	public static void main(String[] args) throws Exception {
+		ErrorCallBack handler = new ErrorCallBack() {
+			@Override
+			public void error(String line, String details, Exception e) {
+				System.err.println(line + ":" + details);
+			}		
+		};
+		ContentInfoUtil util = args.length == 0 ? new ContentInfoUtil(handler) :
+			new ContentInfoUtil(new FileReader(args[0]), handler);
+		Field entriesField = ContentInfoUtil.class.getDeclaredField("magicEntries");
+		entriesField.setAccessible(true);
+		MagicEntries entries = (MagicEntries) entriesField.get(util);
+		Field entryListField = MagicEntries.class.getDeclaredField("entryList");
+		entryListField.setAccessible(true); 
+		@SuppressWarnings("unchecked")
+		List<MagicEntry> entryList = (List<MagicEntry>) entryListField.get(entries);
+		for (MagicEntry entry: entryList) {
+			System.out.println(entry.toString2());
+		}
+	}
+}


### PR DESCRIPTION
This utility allows you to parse and dump a "magic" config file.  I had to add extra toString / toString2 methods to expose the full state of an entry and its children.