### PR TITLE
Preparations for v5.38 "file" command compatibility update

### DIFF
--- a/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
@@ -1,5 +1,6 @@
 package com.j256.simplemagic.entries;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +18,7 @@ import com.j256.simplemagic.logger.LoggerFactory;
  */
 public class MagicEntry {
 
-	private static Logger logger = LoggerFactory.getLogger(MagicEntry.class);
+	private static final Logger LOGGER = LoggerFactory.getLogger(MagicEntry.class);
 
 	private final String name;
 	private final int level;
@@ -25,7 +26,7 @@ public class MagicEntry {
 	private final int offset;
 	private final OffsetInfo offsetInfo;
 	private final MagicMatcher matcher;
-	private final Long andValue;
+	private final BigInteger andValue;
 	private final boolean unsignedType;
 	// the testValue object is defined by the particular matcher
 	private final Object testValue;
@@ -42,8 +43,8 @@ public class MagicEntry {
 	 * Package protected constructor.
 	 */
 	MagicEntry(String name, int level, boolean addOffset, int offset, OffsetInfo offsetInfo, MagicMatcher matcher,
-			Long andValue, boolean unsignedType, Object testValue, boolean formatSpacePrefix, boolean clearFormat,
-			MagicFormatter formatter) {
+			   BigInteger andValue, boolean unsignedType, Object testValue, boolean formatSpacePrefix, boolean clearFormat,
+			   MagicFormatter formatter) {
 		this.name = name;
 		this.level = level;
 		this.addOffset = addOffset;
@@ -169,7 +170,7 @@ public class MagicEntry {
 			}
 			matcher.renderValue(contentData.sb, val, formatter);
 		}
-		logger.trace("matched data: {}: {}", this, contentData);
+		LOGGER.trace("matched data: {}: {}", this, contentData);
 
 		if (children == null) {
 			// no children so we have a full match and can set partial to false
@@ -251,9 +252,9 @@ public class MagicEntry {
 		public Integer getOffset(byte[] bytes) {
 			Long val;
 			if (isId3) {
-				val = (Long) converter.convertId3(offset, bytes, size);
+				val = converter.convertId3(offset, bytes, size);
 			} else {
-				val = (Long) converter.convertNumber(offset, bytes, size);
+				val = converter.convertNumber(offset, bytes, size);
 			}
 			if (val == null) {
 				return null;

--- a/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicEntry.java
@@ -18,7 +18,7 @@ import com.j256.simplemagic.logger.LoggerFactory;
  */
 public class MagicEntry {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(MagicEntry.class);
+	private static final Logger logger = LoggerFactory.getLogger(MagicEntry.class);
 
 	private final String name;
 	private final int level;
@@ -43,8 +43,8 @@ public class MagicEntry {
 	 * Package protected constructor.
 	 */
 	MagicEntry(String name, int level, boolean addOffset, int offset, OffsetInfo offsetInfo, MagicMatcher matcher,
-			   BigInteger andValue, boolean unsignedType, Object testValue, boolean formatSpacePrefix, boolean clearFormat,
-			   MagicFormatter formatter) {
+			BigInteger andValue, boolean unsignedType, Object testValue, boolean formatSpacePrefix, boolean clearFormat,
+			MagicFormatter formatter) {
 		this.name = name;
 		this.level = level;
 		this.addOffset = addOffset;
@@ -170,7 +170,7 @@ public class MagicEntry {
 			}
 			matcher.renderValue(contentData.sb, val, formatter);
 		}
-		LOGGER.trace("matched data: {}: {}", this, contentData);
+		logger.trace("matched data: {}: {}", this, contentData);
 
 		if (children == null) {
 			// no children so we have a full match and can set partial to false

--- a/src/main/java/com/j256/simplemagic/entries/MagicEntryParser.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicEntryParser.java
@@ -100,30 +100,30 @@ public class MagicEntryParser {
 			}
 		}
 
-        // process the AND (&) part of the type
-        String typeStr = parts[1];
-        sindex = typeStr.indexOf('&');
-        // we use BigInteger because of overlaps
-        BigInteger andValue = null;
-        if (sindex >= 0) {
-            String andStr = typeStr.substring(sindex + 1);
-            try {
-                Matcher matcher = HEX_PATTERN.matcher(andStr);
-                andValue = matcher.matches() ? new BigInteger(matcher.group(1), 16) : new BigInteger(andStr);
-            } catch (NumberFormatException e) {
-                if (errorCallBack != null) {
-                    errorCallBack.error(line, "invalid type AND-number: " + andStr, e);
-                }
-                return null;
-            }
-            typeStr = typeStr.substring(0, sindex);
-        }
-        if (typeStr.length() == 0) {
-            if (errorCallBack != null) {
-                errorCallBack.error(line, "blank type string", null);
-            }
-            return null;
-        }
+		// process the AND (&) part of the type
+		String typeStr = parts[1];
+		sindex = typeStr.indexOf('&');
+		// we use BigInteger because of overlaps
+		BigInteger andValue = null;
+		if (sindex >= 0) {
+			String andStr = typeStr.substring(sindex + 1);
+			try {
+				Matcher matcher = HEX_PATTERN.matcher(andStr);
+				andValue = matcher.matches() ? new BigInteger(matcher.group(1), 16) : new BigInteger(andStr);
+			} catch (NumberFormatException e) {
+				if (errorCallBack != null) {
+					errorCallBack.error(line, "invalid type AND-number: " + andStr, e);
+				}
+				return null;
+			}
+			typeStr = typeStr.substring(0, sindex);
+		}
+		if (typeStr.length() == 0) {
+			if (errorCallBack != null) {
+				errorCallBack.error(line, "blank type string", null);
+			}
+			return null;
+		}
 
 		// process the type string
 		boolean unsignedType = false;
@@ -198,8 +198,9 @@ public class MagicEntryParser {
 				name = trimmedFormat;
 			}
 		}
-		return new MagicEntry(name, level, addOffset, offset, offsetInfo, matcher, andValue, unsignedType,
+		MagicEntry entry = new MagicEntry(name, level, addOffset, offset, offsetInfo, matcher, andValue, unsignedType,
 				testValue, formatSpacePrefix, clearFormat, formatter);
+		return entry;
 	}
 
 	private static String[] splitLine(String line, ErrorCallBack errorCallBack) {
@@ -252,24 +253,24 @@ public class MagicEntryParser {
 		}
 		String testStr = line.substring(startPos, endPos);
 		// Search operand for isolated operators
-		if(TestOperator.fromTest(testStr) != null && testStr.length()==1){
-            // skip any whitespace to find operand
-            startPos = findNonWhitespace(line, endPos + 1);
+		if (TestOperator.fromTest(testStr) != null && testStr.length() == 1) {
+			// skip any whitespace to find operand
+			startPos = findNonWhitespace(line, endPos + 1);
 
-            // if there is no operand, then the operator is isolated and the testString is erroneous.
-            if (startPos < 0) {
-                if (errorCallBack != null) {
-                    errorCallBack.error(line, String.format("No operand found for: %s", testStr), null);
-                }
-                return null;
-            }
-            endPos = findWhitespaceWithoutEscape(line, startPos);
-            if (endPos < 0) {
-                endPos = line.length();
-            }
-            // the following element must be the operand, else the testString is erroneous anyway. Append it!
-            testStr+=line.substring(startPos, endPos);
-        }
+			// if there is no operand, then the operator is isolated and the testString is erroneous.
+			if (startPos < 0) {
+				if (errorCallBack != null) {
+					errorCallBack.error(line, String.format("No operand found for: %s", testStr), null);
+				}
+				return null;
+			}
+			endPos = findWhitespaceWithoutEscape(line, startPos);
+			if (endPos < 0) {
+				endPos = line.length();
+			}
+			// the following element must be the operand, else the testString is erroneous anyway. Append it!
+			testStr += line.substring(startPos, endPos);
+		}
 
 		// skip any whitespace
 		startPos = findNonWhitespace(line, endPos + 1);

--- a/src/main/java/com/j256/simplemagic/entries/MagicMatcher.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicMatcher.java
@@ -1,5 +1,7 @@
 package com.j256.simplemagic.entries;
 
+import java.math.BigInteger;
+
 /**
  * Classes which are able to match content according to operations and output description.
  * 
@@ -9,9 +11,9 @@ public interface MagicMatcher {
 
 	/**
 	 * Converts the test-string from the magic line to be the testValue object to be passed into
-	 * {@link #isMatch(Object, Long, boolean, Object, MutableOffset, byte[])} and {@link #getStartingBytes(Object)}.
+	 * {@link #isMatch(Object, BigInteger, boolean, Object, MutableOffset, byte[])} and {@link #getStartingBytes(Object)}.
 	 */
-	public Object convertTestString(String typeStr, String testStr);
+	Object convertTestString(String typeStr, String testStr);
 
 	/**
 	 * Extract the value from the bytes either for doing the match or rendering it in the format.
@@ -23,33 +25,33 @@ public interface MagicMatcher {
 	 * @param required
 	 *            Whether or not the extracted value is required for later. If it is not then the type may opt to not
 	 *            extract the value and to do the matching directly.
-	 * @return The object to be passed to {@link #isMatch(Object, Long, boolean, Object, MutableOffset, byte[])} or null
+	 * @return The object to be passed to {@link #isMatch(Object, BigInteger, boolean, Object, MutableOffset, byte[])} or null
 	 *         if not enough bytes.
 	 */
-	public Object extractValueFromBytes(int offset, byte[] bytes, boolean required);
+	Object extractValueFromBytes(int offset, byte[] bytes, boolean required);
 
 	/**
 	 * Matches if the bytes match at a certain offset.
 	 * 
 	 * @return The extracted-value object, or null if no match.
 	 */
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset offset, byte[] bytes);
+	Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset offset, byte[] bytes);
 
 	/**
 	 * Returns the string version of the extracted value.
 	 */
-	public void renderValue(StringBuilder sb, Object extractedValue, MagicFormatter formatter);
+	void renderValue(StringBuilder sb, Object extractedValue, MagicFormatter formatter);
 
 	/**
 	 * Return the starting bytes of the pattern or null if none.
 	 */
-	public byte[] getStartingBytes(Object testValue);
+	byte[] getStartingBytes(Object testValue);
 
 	/**
 	 * Offset which we can update.
 	 */
-	public static class MutableOffset {
+	class MutableOffset {
 		public int offset;
 
 		public MutableOffset(int offset) {

--- a/src/main/java/com/j256/simplemagic/entries/MagicMatcher.java
+++ b/src/main/java/com/j256/simplemagic/entries/MagicMatcher.java
@@ -13,7 +13,7 @@ public interface MagicMatcher {
 	 * Converts the test-string from the magic line to be the testValue object to be passed into
 	 * {@link #isMatch(Object, BigInteger, boolean, Object, MutableOffset, byte[])} and {@link #getStartingBytes(Object)}.
 	 */
-	Object convertTestString(String typeStr, String testStr);
+	public Object convertTestString(String typeStr, String testStr);
 
 	/**
 	 * Extract the value from the bytes either for doing the match or rendering it in the format.
@@ -28,30 +28,30 @@ public interface MagicMatcher {
 	 * @return The object to be passed to {@link #isMatch(Object, BigInteger, boolean, Object, MutableOffset, byte[])} or null
 	 *         if not enough bytes.
 	 */
-	Object extractValueFromBytes(int offset, byte[] bytes, boolean required);
+	public Object extractValueFromBytes(int offset, byte[] bytes, boolean required);
 
 	/**
 	 * Matches if the bytes match at a certain offset.
 	 * 
 	 * @return The extracted-value object, or null if no match.
 	 */
-	Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset offset, byte[] bytes);
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+			MutableOffset offset, byte[] bytes);
 
 	/**
 	 * Returns the string version of the extracted value.
 	 */
-	void renderValue(StringBuilder sb, Object extractedValue, MagicFormatter formatter);
+	public void renderValue(StringBuilder sb, Object extractedValue, MagicFormatter formatter);
 
 	/**
 	 * Return the starting bytes of the pattern or null if none.
 	 */
-	byte[] getStartingBytes(Object testValue);
+	public byte[] getStartingBytes(Object testValue);
 
 	/**
 	 * Offset which we can update.
 	 */
-	class MutableOffset {
+	public class MutableOffset {
 		public int offset;
 
 		public MutableOffset(int offset) {

--- a/src/main/java/com/j256/simplemagic/entries/PercentExpression.java
+++ b/src/main/java/com/j256/simplemagic/entries/PercentExpression.java
@@ -1,7 +1,9 @@
 package com.j256.simplemagic.entries;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.Format;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -348,14 +350,14 @@ public class PercentExpression {
 	private Format decimalFormat(int fractionPrecision) {
 		DecimalFormat format;
 		if (fractionPrecision == 0) {
-			format = new DecimalFormat("###0");
+			format = new DecimalFormat("###0", new DecimalFormatSymbols(Locale.US));
 		} else if (fractionPrecision > 0) {
 			StringBuilder formatSb = new StringBuilder();
 			formatSb.append("###0.");
 			appendChars(formatSb, ZERO_CHARS, fractionPrecision);
-			format = new DecimalFormat(formatSb.toString());
+			format = new DecimalFormat(formatSb.toString(), new DecimalFormatSymbols(Locale.US));
 		} else {
-			format = new DecimalFormat("###0.###");
+			format = new DecimalFormat("###0.###", new DecimalFormatSymbols(Locale.US));
 		}
 		return format;
 	}
@@ -363,15 +365,15 @@ public class PercentExpression {
 	private Format scientificFormat(int fractionPrecision) {
 		DecimalFormat format;
 		if (fractionPrecision == 0) {
-			format = new DecimalFormat("0E0");
+			format = new DecimalFormat("0E0", new DecimalFormatSymbols(Locale.US));
 		} else if (fractionPrecision > 0) {
 			StringBuilder formatSb = new StringBuilder();
 			formatSb.append("0.");
 			appendChars(formatSb, ZERO_CHARS, fractionPrecision);
 			formatSb.append("E0");
-			format = new DecimalFormat(formatSb.toString());
+			format = new DecimalFormat(formatSb.toString(), new DecimalFormatSymbols(Locale.US));
 		} else {
-			format = new DecimalFormat("0.###E0");
+			format = new DecimalFormat("0.###E0", new DecimalFormatSymbols(Locale.US));
 		}
 		return format;
 	}

--- a/src/main/java/com/j256/simplemagic/types/BaseLongType.java
+++ b/src/main/java/com/j256/simplemagic/types/BaseLongType.java
@@ -2,25 +2,29 @@ package com.j256.simplemagic.types;
 
 import com.j256.simplemagic.endian.EndianType;
 
+import java.math.BigInteger;
+import java.util.regex.Matcher;
+
 /**
  * Base class for those types which use long types to compare.
- * 
+ *
  * @author graywatson
  */
 public abstract class BaseLongType extends NumberType {
 
-	public BaseLongType(EndianType endianType) {
-		super(endianType);
-	}
+    public BaseLongType(EndianType endianType) {
+        super(endianType);
+    }
 
-	@Override
-	public Number decodeValueString(String valueStr) throws NumberFormatException {
-		return Long.decode(valueStr);
-	}
+    @Override
+    public Number decodeValueString(String valueStr) throws NumberFormatException {
+        Matcher matcher = HEX_PATTERN.matcher(valueStr);
+        return matcher.matches() ? new BigInteger(matcher.group(1), 16) : new BigInteger(valueStr);
+    }
 
-	@Override
-	public byte[] getStartingBytes(Object testValue) {
-		return endianConverter.convertToByteArray(((NumberComparison) testValue).getValue().longValue(),
-				getBytesPerType());
-	}
+    @Override
+    public byte[] getStartingBytes(Object testValue) {
+        return endianConverter.convertToByteArray(((NumberComparison) testValue).getValue().longValue(),
+            getBytesPerType());
+    }
 }

--- a/src/main/java/com/j256/simplemagic/types/BaseLongType.java
+++ b/src/main/java/com/j256/simplemagic/types/BaseLongType.java
@@ -12,19 +12,19 @@ import java.util.regex.Matcher;
  */
 public abstract class BaseLongType extends NumberType {
 
-    public BaseLongType(EndianType endianType) {
-        super(endianType);
-    }
+	public BaseLongType(EndianType endianType) {
+		super(endianType);
+	}
 
-    @Override
-    public Number decodeValueString(String valueStr) throws NumberFormatException {
-        Matcher matcher = HEX_PATTERN.matcher(valueStr);
-        return matcher.matches() ? new BigInteger(matcher.group(1), 16) : new BigInteger(valueStr);
-    }
+	@Override
+	public Number decodeValueString(String valueStr) throws NumberFormatException {
+		Matcher matcher = HEX_PATTERN.matcher(valueStr);
+		return matcher.matches() ? new BigInteger(matcher.group(1), 16) : new BigInteger(valueStr);
+	}
 
-    @Override
-    public byte[] getStartingBytes(Object testValue) {
-        return endianConverter.convertToByteArray(((NumberComparison) testValue).getValue().longValue(),
-            getBytesPerType());
-    }
+	@Override
+	public byte[] getStartingBytes(Object testValue) {
+		return endianConverter.convertToByteArray(((NumberComparison) testValue).getValue().longValue(),
+				getBytesPerType());
+	}
 }

--- a/src/main/java/com/j256/simplemagic/types/BigEndianString16Type.java
+++ b/src/main/java/com/j256/simplemagic/types/BigEndianString16Type.java
@@ -27,7 +27,7 @@ public class BigEndianString16Type extends StringType {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 		// we do the match on the extracted chars
 		char[] chars = (char[]) extractedValue;
 		return super.findOffsetMatch((TestInfo) testValue, mutableOffset.offset, mutableOffset, null, chars,

--- a/src/main/java/com/j256/simplemagic/types/BigEndianString16Type.java
+++ b/src/main/java/com/j256/simplemagic/types/BigEndianString16Type.java
@@ -1,5 +1,7 @@
 package com.j256.simplemagic.types;
 
+import java.math.BigInteger;
+
 /**
  * A two-byte unicode (UCS16) string in big-endian byte order.
  * 
@@ -24,8 +26,8 @@ public class BigEndianString16Type extends StringType {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 		// we do the match on the extracted chars
 		char[] chars = (char[]) extractedValue;
 		return super.findOffsetMatch((TestInfo) testValue, mutableOffset.offset, mutableOffset, null, chars,

--- a/src/main/java/com/j256/simplemagic/types/DefaultType.java
+++ b/src/main/java/com/j256/simplemagic/types/DefaultType.java
@@ -32,7 +32,7 @@ public class DefaultType implements MagicMatcher {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset offset, byte[] bytes) {
+			MutableOffset offset, byte[] bytes) {
 		// always matches
 		return EMPTY;
 	}

--- a/src/main/java/com/j256/simplemagic/types/DefaultType.java
+++ b/src/main/java/com/j256/simplemagic/types/DefaultType.java
@@ -3,6 +3,8 @@ package com.j256.simplemagic.types;
 import com.j256.simplemagic.entries.MagicFormatter;
 import com.j256.simplemagic.entries.MagicMatcher;
 
+import java.math.BigInteger;
+
 /**
  * This is intended to be used with the test @code{x} (which is always true) and a message that is to be used if there
  * are no other matches.
@@ -29,8 +31,8 @@ public class DefaultType implements MagicMatcher {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset offset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset offset, byte[] bytes) {
 		// always matches
 		return EMPTY;
 	}

--- a/src/main/java/com/j256/simplemagic/types/NumberComparison.java
+++ b/src/main/java/com/j256/simplemagic/types/NumberComparison.java
@@ -1,5 +1,7 @@
 package com.j256.simplemagic.types;
 
+import java.math.BigInteger;
+
 /**
  * Internal class that compares a number from the bytes with the value from the magic rule.
  */
@@ -30,9 +32,9 @@ public class NumberComparison {
 		}
 	}
 
-	public boolean isMatch(Long andValue, boolean unsignedType, Number extractedValue) {
+	public boolean isMatch(BigInteger andValue, boolean unsignedType, Number extractedValue) {
 		if (andValue != null) {
-			extractedValue = extractedValue.longValue() & andValue;
+			extractedValue = BigInteger.valueOf(extractedValue.longValue()).and(andValue);
 		}
 		return operator.doTest(unsignedType, extractedValue, value, numberType);
 	}

--- a/src/main/java/com/j256/simplemagic/types/NumberType.java
+++ b/src/main/java/com/j256/simplemagic/types/NumberType.java
@@ -55,7 +55,7 @@ public abstract class NumberType implements MagicMatcher {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 		if (((NumberComparison) testValue).isMatch(andValue, unsignedType, (Number) extractedValue)) {
 			mutableOffset.offset += getBytesPerType();
 			return extractedValue;

--- a/src/main/java/com/j256/simplemagic/types/NumberType.java
+++ b/src/main/java/com/j256/simplemagic/types/NumberType.java
@@ -5,12 +5,17 @@ import com.j256.simplemagic.endian.EndianType;
 import com.j256.simplemagic.entries.MagicFormatter;
 import com.j256.simplemagic.entries.MagicMatcher;
 
+import java.math.BigInteger;
+import java.util.regex.Pattern;
+
 /**
  * Base class for our numbers so we can do generic operations on them.
  * 
  * @author graywatson
  */
 public abstract class NumberType implements MagicMatcher {
+
+	public static final Pattern HEX_PATTERN = Pattern.compile("0[xX]([0-9a-fA-F]+)");
 
 	protected final EndianConverter endianConverter;
 
@@ -49,8 +54,8 @@ public abstract class NumberType implements MagicMatcher {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 		if (((NumberComparison) testValue).isMatch(andValue, unsignedType, (Number) extractedValue)) {
 			mutableOffset.offset += getBytesPerType();
 			return extractedValue;

--- a/src/main/java/com/j256/simplemagic/types/PStringType.java
+++ b/src/main/java/com/j256/simplemagic/types/PStringType.java
@@ -40,7 +40,7 @@ public class PStringType extends StringType {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 
 		if (mutableOffset.offset >= bytes.length) {
 			return null;

--- a/src/main/java/com/j256/simplemagic/types/PStringType.java
+++ b/src/main/java/com/j256/simplemagic/types/PStringType.java
@@ -1,5 +1,7 @@
 package com.j256.simplemagic.types;
 
+import java.math.BigInteger;
+
 /**
  * A Pascal-style string where the first byte is interpreted as the an unsigned length. The string is not '\0'
  * terminated.
@@ -37,8 +39,8 @@ public class PStringType extends StringType {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 
 		if (mutableOffset.offset >= bytes.length) {
 			return null;

--- a/src/main/java/com/j256/simplemagic/types/RegexType.java
+++ b/src/main/java/com/j256/simplemagic/types/RegexType.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.math.BigInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,8 +54,8 @@ public class RegexType implements MagicMatcher {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
 		String line = null;
 		int bytesOffset = 0;

--- a/src/main/java/com/j256/simplemagic/types/RegexType.java
+++ b/src/main/java/com/j256/simplemagic/types/RegexType.java
@@ -55,7 +55,7 @@ public class RegexType implements MagicMatcher {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes)));
 		String line = null;
 		int bytesOffset = 0;

--- a/src/main/java/com/j256/simplemagic/types/SearchType.java
+++ b/src/main/java/com/j256/simplemagic/types/SearchType.java
@@ -1,5 +1,7 @@
 package com.j256.simplemagic.types;
 
+import java.math.BigInteger;
+
 /**
  * From the magic(5) man page: A literal string search starting at the given line offset. The same modifier flags can be
  * used as for string patterns. The modifier flags (if any) must be followed by /number range, that is, the number of
@@ -16,8 +18,8 @@ package com.j256.simplemagic.types;
 public class SearchType extends StringType {
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 		TestInfo info = (TestInfo) testValue;
 		int maxOffset = info.maxOffset;
 		if (info.optionalWhiteSpace) {

--- a/src/main/java/com/j256/simplemagic/types/SearchType.java
+++ b/src/main/java/com/j256/simplemagic/types/SearchType.java
@@ -19,7 +19,7 @@ public class SearchType extends StringType {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 		TestInfo info = (TestInfo) testValue;
 		int maxOffset = info.maxOffset;
 		if (info.optionalWhiteSpace) {

--- a/src/main/java/com/j256/simplemagic/types/StringType.java
+++ b/src/main/java/com/j256/simplemagic/types/StringType.java
@@ -88,7 +88,7 @@ public class StringType implements MagicMatcher {
 
 	@Override
 	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
-						  MutableOffset mutableOffset, byte[] bytes) {
+			MutableOffset mutableOffset, byte[] bytes) {
 		return findOffsetMatch((TestInfo) testValue, mutableOffset.offset, mutableOffset, bytes, null, bytes.length);
 	}
 
@@ -223,8 +223,8 @@ public class StringType implements MagicMatcher {
 			if (pattern == null || pattern.length() < 4) {
 				return null;
 			} else {
-				return new byte[] { (byte) pattern.charAt(0), (byte) pattern.charAt(1), (byte) pattern.charAt(2),
-						(byte) pattern.charAt(3) };
+				return new byte[]{(byte) pattern.charAt(0), (byte) pattern.charAt(1), (byte) pattern.charAt(2),
+						(byte) pattern.charAt(3)};
 			}
 		}
 

--- a/src/main/java/com/j256/simplemagic/types/StringType.java
+++ b/src/main/java/com/j256/simplemagic/types/StringType.java
@@ -1,5 +1,6 @@
 package com.j256.simplemagic.types;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -86,8 +87,8 @@ public class StringType implements MagicMatcher {
 	}
 
 	@Override
-	public Object isMatch(Object testValue, Long andValue, boolean unsignedType, Object extractedValue,
-			MutableOffset mutableOffset, byte[] bytes) {
+	public Object isMatch(Object testValue, BigInteger andValue, boolean unsignedType, Object extractedValue,
+						  MutableOffset mutableOffset, byte[] bytes) {
 		return findOffsetMatch((TestInfo) testValue, mutableOffset.offset, mutableOffset, bytes, null, bytes.length);
 	}
 

--- a/src/test/java/com/j256/simplemagic/entries/MagicEntryParserTest.java
+++ b/src/test/java/com/j256/simplemagic/entries/MagicEntryParserTest.java
@@ -111,6 +111,54 @@ public class MagicEntryParserTest {
 		assertNotNull(error.details);
 	}
 
+    @Test
+    public void testBigIntegerHexValues() {
+        //Ensure usage of BigInteger does not fail for Type AND-number.
+		MagicEntry entry = MagicEntryParser.parseLine(null, ">0x01C\tulequad&0xFFFFFFFCFFFFFFFC\t=0x0000000000000000", null);
+        assertNotNull(entry);
+
+        //Ensure usage of BigInteger does not fail for testValue parsing.
+        entry = MagicEntryParser.parseLine(null, ">>5\tlequad\t\t!0xffffffffffffffff\tnon-streamed, size %lld", null);
+        assertNotNull(entry);
+    }
+
+	@Test
+	public void testTestValueContainsWhitespace() {
+        //EQUALS operator followed by whitespace and operand shall be valid
+        MagicEntry entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t= 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //NOT-EQUALS operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t! 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //GREATER-THAN operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t> 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //LESS-THAN operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t< 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //AND-ALL-SET operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t& 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //AND-ALL-CLEARED operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t^ 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //NEGATE operator followed by whitespace and operand shall be valid
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t~ 10\tInfocom (Z-machine %d", null);
+        assertNotNull(entry);
+
+        //UNKNOWN operator followed by whitespace and operand shall be invalid
+        LocalErrorCallBack error = new LocalErrorCallBack();
+        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t. 10\tInfocom (Z-machine %d", error);
+        assertNull(entry);
+        assertNotNull(error.details);
+	}
+
 	private static class LocalErrorCallBack implements ErrorCallBack {
 		@SuppressWarnings("unused")
 		String line;

--- a/src/test/java/com/j256/simplemagic/entries/MagicEntryParserTest.java
+++ b/src/test/java/com/j256/simplemagic/entries/MagicEntryParserTest.java
@@ -111,52 +111,52 @@ public class MagicEntryParserTest {
 		assertNotNull(error.details);
 	}
 
-    @Test
-    public void testBigIntegerHexValues() {
-        //Ensure usage of BigInteger does not fail for Type AND-number.
+	@Test
+	public void testBigIntegerHexValues() {
+		//Ensure usage of BigInteger does not fail for Type AND-number.
 		MagicEntry entry = MagicEntryParser.parseLine(null, ">0x01C\tulequad&0xFFFFFFFCFFFFFFFC\t=0x0000000000000000", null);
-        assertNotNull(entry);
+		assertNotNull(entry);
 
-        //Ensure usage of BigInteger does not fail for testValue parsing.
-        entry = MagicEntryParser.parseLine(null, ">>5\tlequad\t\t!0xffffffffffffffff\tnon-streamed, size %lld", null);
-        assertNotNull(entry);
-    }
+		//Ensure usage of BigInteger does not fail for testValue parsing.
+		entry = MagicEntryParser.parseLine(null, ">>5\tlequad\t\t!0xffffffffffffffff\tnon-streamed, size %lld", null);
+		assertNotNull(entry);
+	}
 
 	@Test
 	public void testTestValueContainsWhitespace() {
-        //EQUALS operator followed by whitespace and operand shall be valid
-        MagicEntry entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t= 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//EQUALS operator followed by whitespace and operand shall be valid
+		MagicEntry entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t= 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //NOT-EQUALS operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t! 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//NOT-EQUALS operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t! 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //GREATER-THAN operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t> 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//GREATER-THAN operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t> 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //LESS-THAN operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t< 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//LESS-THAN operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t< 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //AND-ALL-SET operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t& 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//AND-ALL-SET operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t& 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //AND-ALL-CLEARED operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t^ 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//AND-ALL-CLEARED operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t^ 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //NEGATE operator followed by whitespace and operand shall be valid
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t~ 10\tInfocom (Z-machine %d", null);
-        assertNotNull(entry);
+		//NEGATE operator followed by whitespace and operand shall be valid
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t~ 10\tInfocom (Z-machine %d", null);
+		assertNotNull(entry);
 
-        //UNKNOWN operator followed by whitespace and operand shall be invalid
-        LocalErrorCallBack error = new LocalErrorCallBack();
-        entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t. 10\tInfocom (Z-machine %d", error);
-        assertNull(entry);
-        assertNotNull(error.details);
+		//UNKNOWN operator followed by whitespace and operand shall be invalid
+		LocalErrorCallBack error = new LocalErrorCallBack();
+		entry = MagicEntryParser.parseLine(null, ">>>>>>0\tubyte\t\t\t. 10\tInfocom (Z-machine %d", error);
+		assertNull(entry);
+		assertNotNull(error.details);
 	}
 
 	private static class LocalErrorCallBack implements ErrorCallBack {

--- a/src/test/java/com/j256/simplemagic/types/LongTypeTest.java
+++ b/src/test/java/com/j256/simplemagic/types/LongTypeTest.java
@@ -40,6 +40,14 @@ public class LongTypeTest extends BaseMagicTypeTest {
 
 		bytes = hexToBytes("FFFFFFFFFFFFFFFF");
 		testOutput(magic, bytes, null);
+
+		magic = "0 bequad =0xFFFFFFFFFFFFFFFF match";
+		bytes = hexToBytes("FFFFFFFFFFFFFFFF");
+		testOutput(magic, bytes, "match");
+
+		magic = "0 bequad =0xFFFFFFFFFFFFFFFF match";
+		bytes = hexToBytes("0000000000000000");
+		testOutput(magic, bytes, null);
 	}
 
 	@Test


### PR DESCRIPTION
This library is amazing and we really want to use it in combination with the current magic patterns for the update 5.38 of the unix file command. (https://github.com/file/file/tree/master/magic/Magdir)
To reach this goal, we will have to update and alter some definitions and methods of your library. We created this Fork to implement said missing definitions and to contribute those changes (if you are interested).
Meaning: Further changes will follow.

This first pull request is intended more or less to ask the simple question, whether you would be interested in our suggestions and if we shall and may make further pull requests.

**In this first minor pull request we suggest to change the following two things:**
- We enabled the handling of whitespaces in between the operator and operand of a Test String, by making the contextual assumption, that none of the already defined TestOperators is valid without an operand in the test String. (which enabled simple magic to interpret some further magic patterns from 5.38 correctly)
- We suggest to use BigInteger instead of Long for testString and type "AND-value" parsing, as some hexadecimal values from the 5.38 patterns are exceeding the Long range.